### PR TITLE
Add private sdk and configure path from config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,17 +6,18 @@ import (
 	goauth2 "golang.org/x/oauth2"
 )
 
-// Config holds the configuration values required for the `go-sdk-manager`
+// Config holds the configuration values required for the `api-sdk-manager-go-library`
 type Config struct {
-	gofigure     interface{} `order:"env,flag"`
-	ClientID     string      `env:"OAUTH2_CLIENT_ID"     flag:"oauth2-client-id"     flagDesc:"Client ID"`
-	ClientSecret string      `env:"OAUTH2_CLIENT_SECRET" flag:"oauth2-client-secret" flagDesc:"Client Secret"`
-	RedirectURL  string      `env:"OAUTH2_REDIRECT_URI"  flag:"oauth2-redirect-uri"  flagDesc:"Oauth2 Redirect URI"`
-	AuthURL      string      `env:"OAUTH2_AUTH_URI"      flag:"oauth2-auth-uri"      flagDesc:"Oauth2 Auth URI"`
-	TokenURL     string      `env:"OAUTH2_TOKEN_URI"     flag:"oauth2-token-uri"     flagDesc:"Oauth2 Token URI"`
-	Scopes       []string    `env:"SCOPE"                flag:"scope"                flagDesc:"Scope"`
-	APIKey       string      `env:"API_KEY"              flag:"api-key"              flagDesc:"API Key"`
-	APIURL       string      `env:"API_URL"              flag:"api-url"              flagDesc:"API URL"`
+	gofigure        interface{} `order:"env,flag"`
+	ClientID        string      `env:"OAUTH2_CLIENT_ID"     flag:"oauth2-client-id"     flagDesc:"Client ID"`
+	ClientSecret    string      `env:"OAUTH2_CLIENT_SECRET" flag:"oauth2-client-secret" flagDesc:"Client Secret"`
+	RedirectURL     string      `env:"OAUTH2_REDIRECT_URI"  flag:"oauth2-redirect-uri"  flagDesc:"Oauth2 Redirect URI"`
+	AuthURL         string      `env:"OAUTH2_AUTH_URI"      flag:"oauth2-auth-uri"      flagDesc:"Oauth2 Auth URI"`
+	TokenURL        string      `env:"OAUTH2_TOKEN_URI"     flag:"oauth2-token-uri"     flagDesc:"Oauth2 Token URI"`
+	Scopes          []string    `env:"SCOPE"                flag:"scope"                flagDesc:"Scope"`
+	APIKey          string      `env:"API_KEY"              flag:"api-key"              flagDesc:"API Key"`
+	APIURL          string      `env:"API_URL"              flag:"api-url"              flagDesc:"API URL"`
+	PostcodeService string      `env:"POSTCODE_SERVICE"     flag:"postcode-service"     flagDesc:"Postcode Service"`
 }
 
 var oauthConfig *choauth2.Config

--- a/manager/api_sdk_manager.go
+++ b/manager/api_sdk_manager.go
@@ -8,11 +8,13 @@ import (
 	sdk "github.com/companieshouse/api-sdk-go/companieshouseapi"
 	choauth2 "github.com/companieshouse/api-sdk-go/oauth2"
 	"github.com/companieshouse/api-sdk-manager-go-library/config"
+	privatesdk "github.com/companieshouse/private-api-sdk-go/companieshouseapi"
 	"github.com/pkg/errors"
 	goauth2 "golang.org/x/oauth2"
 )
 
-var basePathOverridden = false
+var sdkBasePathOverridden = false
+var privateSdkBasePathOverridden = false
 
 // GetSDK will return an instance of the Go SDK using an oauth2 authenticated
 // HTTP client if possible, else an API-key authenticated HTTP client will be used
@@ -23,10 +25,10 @@ func GetSDK(req *http.Request) (*sdk.Service, error) {
 		return nil, err
 	}
 
-	// Override BasePath here to route API requests via ERIC
-	if !basePathOverridden && len(cfg.APIURL) > 0 {
+	// Override sdkBasePath here to route API requests via ERIC
+	if !sdkBasePathOverridden && len(cfg.APIURL) > 0 {
 		sdk.BasePath = cfg.APIURL
-		basePathOverridden = true
+		sdkBasePathOverridden = true
 	}
 
 	httpClient, err := getHTTPClient(req)
@@ -35,6 +37,30 @@ func GetSDK(req *http.Request) (*sdk.Service, error) {
 	}
 
 	return sdk.New(httpClient)
+}
+
+// GetPrivateSDK will return an instance of the Private Go SDK using an oauth2 authenticated
+// HTTP client if possible, else an API-key authenticated HTTP client will be used
+func GetPrivateSDK(req *http.Request) (*privatesdk.Service, error) {
+
+	cfg, err := config.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	// Override privateSdkBasePath here to route API requests via ERIC
+	if !privateSdkBasePathOverridden && len(cfg.APIURL) > 0 {
+		privatesdk.BasePath = cfg.APIURL
+		privatesdk.PostcodeBasePath = cfg.PostcodeService
+		privateSdkBasePathOverridden = true
+	}
+
+	httpClient, err := getHTTPClient(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return privatesdk.New(httpClient)
 }
 
 // getHTTPClient returns an Http Client. It will be either Oauth2 or API-key

--- a/manager/api_sdk_manager_test.go
+++ b/manager/api_sdk_manager_test.go
@@ -53,3 +53,50 @@ func TestGetSDKWithApiKeyAuthentication(t *testing.T) {
 		})
 	})
 }
+
+func TestGetPrivateSDKWithOauth2Authentication(t *testing.T) {
+
+	Convey("Given I have a request with a passthrough token in the header", t, func() {
+
+		req, _ := http.NewRequest("Get", "foo", nil)
+		req.Header.Add("Eric-Access-Token", `{"token_type":"bearer","access_token":"bar","expires_in":1234}`)
+
+		Convey("When I try to retrieve an instance of the SDK", func() {
+
+			service, err := GetPrivateSDK(req)
+
+			Convey("Then no errors should be returned", func() {
+
+				So(err, ShouldBeNil)
+
+				Convey("And the SDK service should not be nil", func() {
+
+					So(service, ShouldNotBeNil)
+				})
+			})
+		})
+	})
+}
+
+func TestGetPrivateSDKWithApiKeyAuthentication(t *testing.T) {
+
+	Convey("Given I have a request without a passthrough token in the header ", t, func() {
+
+		req, _ := http.NewRequest("Get", "foo", nil)
+
+		Convey("When I try to retrieve an instance of the SDK", func() {
+
+			service, err := GetPrivateSDK(req)
+
+			Convey("Then no errors should be returned", func() {
+
+				So(err, ShouldBeNil)
+
+				Convey("And the SDK service should not be nil", func() {
+
+					So(service, ShouldNotBeNil)
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
Allows retrieval of a private api sdk using the manager and configuring correctly.
Configuration requires [this](https://github.com/companieshouse/chs-configs/pull/681)
Part of resolving FA-119