### PR TITLE
Make passthrough token an optional parameter

### DIFF
--- a/manager/api_sdk_manager_test.go
+++ b/manager/api_sdk_manager_test.go
@@ -16,7 +16,7 @@ func TestGetSDKWithOauth2Authentication(t *testing.T) {
 
 		Convey("When I try to retrieve an instance of the SDK", func() {
 
-			service, err := GetSDK(req)
+			service, err := GetSDK(req, true)
 
 			Convey("Then no errors should be returned", func() {
 
@@ -39,7 +39,7 @@ func TestGetSDKWithApiKeyAuthentication(t *testing.T) {
 
 		Convey("When I try to retrieve an instance of the SDK", func() {
 
-			service, err := GetSDK(req)
+			service, err := GetSDK(req, false)
 
 			Convey("Then no errors should be returned", func() {
 


### PR DESCRIPTION
Currently, the SDK always uses the passthrough token if it exists. There may be times when an API key with elevated privileges needs to be used, but gets defaulted to the passthrough token. This change allows the originating service to decide if it wants to use the passthrough token.